### PR TITLE
Enhance cloudstack_zone resource and datasource

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,7 +58,7 @@ signs:
 release:
   disable: false
   github:
-      owner: cloudstack
-      name: terraform-provider-cloudstack
+      owner: ianc769
+      name: cloudstack-terraform-provider
 changelog:
   skip: true

--- a/cloudstack/data_source_cloudstack_zone.go
+++ b/cloudstack/data_source_cloudstack_zone.go
@@ -53,6 +53,46 @@ func dataSourceCloudStackZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"allocationstate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dns2": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domainid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"guestcidraddress": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"internaldns2": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip6dns1": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip6dns2": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"localstorageenabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"securitygroupenabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -92,6 +132,18 @@ func zoneDescriptionAttributes(d *schema.ResourceData, zone *cloudstack.Zone) er
 	d.Set("dns1", zone.Dns1)
 	d.Set("internal_dns1", zone.Internaldns1)
 	d.Set("network_type", zone.Networktype)
+
+	// Set optional fields
+	d.Set("allocationstate", zone.Allocationstate)
+	d.Set("dns2", zone.Dns2)
+	d.Set("domain", zone.Domain)
+	d.Set("domainid", zone.Domainid)
+	d.Set("guestcidraddress", zone.Guestcidraddress)
+	d.Set("internaldns2", zone.Internaldns2)
+	d.Set("ip6dns1", zone.Ip6dns1)
+	d.Set("ip6dns2", zone.Ip6dns2)
+	d.Set("localstorageenabled", zone.Localstorageenabled)
+	d.Set("securitygroupenabled", zone.Securitygroupsenabled)
 
 	return nil
 }

--- a/cloudstack/data_source_cloudstack_zone_test.go
+++ b/cloudstack/data_source_cloudstack_zone_test.go
@@ -37,6 +37,34 @@ func TestAccZoneDataSource_basic(t *testing.T) {
 				Config: testZoneDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "dns1", resourceName, "dns1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "internal_dns1", resourceName, "internal_dns1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_type", resourceName, "network_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccZoneDataSource_extended(t *testing.T) {
+	resourceName := "cloudstack_zone.zone-resource"
+	datasourceName := "data.cloudstack_zone.zone-data-source"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testZoneDataSourceConfig_extended,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "dns1", resourceName, "dns1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "dns2", resourceName, "dns2"),
+					resource.TestCheckResourceAttrPair(datasourceName, "internal_dns1", resourceName, "internal_dns1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "internaldns2", resourceName, "internaldns2"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_type", resourceName, "network_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "guestcidraddress", resourceName, "guestcidraddress"),
+					resource.TestCheckResourceAttrPair(datasourceName, "localstorageenabled", resourceName, "localstorageenabled"),
 				),
 			},
 		},
@@ -44,22 +72,43 @@ func TestAccZoneDataSource_basic(t *testing.T) {
 }
 
 const testZoneDataSourceConfig_basic = `
-resource "cloudstack_zone" "zone-resource"{
-	name       = "TestZone"
-  dns1       = "8.8.8.8"
-  internal_dns1  =  "172.20.0.1"
-  network_type   =  "Advanced"
-  }
+resource "cloudstack_zone" "zone-resource" {
+  name = "TestZone"
+  dns1 = "8.8.8.8"
+  internal_dns1 = "172.20.0.1"
+  network_type = "Advanced"
+}
 
-  data "cloudstack_zone" "zone-data-source"{
-
-    filter{
+data "cloudstack_zone" "zone-data-source" {
+  filter {
     name = "name"
-    value="TestZone"
-    }
-	  depends_on = [
-	  cloudstack_zone.zone-resource
-	]
-  
+    value = "TestZone"
   }
-  `
+  depends_on = [
+    cloudstack_zone.zone-resource
+  ]
+}
+`
+
+const testZoneDataSourceConfig_extended = `
+resource "cloudstack_zone" "zone-resource" {
+  name = "TestZoneExtended"
+  dns1 = "8.8.8.8"
+  dns2 = "8.8.4.4"
+  internal_dns1 = "172.20.0.1"
+  internaldns2 = "172.20.0.2"
+  network_type = "Advanced"
+  guestcidraddress = "10.1.1.0/24"
+  localstorageenabled = true
+}
+
+data "cloudstack_zone" "zone-data-source" {
+  filter {
+    name = "name"
+    value = "TestZoneExtended"
+  }
+  depends_on = [
+    cloudstack_zone.zone-resource
+  ]
+}
+`

--- a/cloudstack/resource_cloudstack_zone.go
+++ b/cloudstack/resource_cloudstack_zone.go
@@ -49,6 +49,55 @@ func resourceCloudStackZone() *schema.Resource {
 			"network_type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
+			},
+			"allocationstate": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dns2": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domainid": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"guestcidraddress": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"internaldns2": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip6dns1": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip6dns2": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"isedge": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"localstorageenabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"securitygroupenabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
 			},
 		},
 	}
@@ -63,6 +112,51 @@ func resourceCloudStackZoneCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// Create a new parameter struct
 	p := cs.Zone.NewCreateZoneParams(dns1, internal_dns1, name, network_type)
+
+	// Set optional parameters
+	if allocationstate, ok := d.GetOk("allocationstate"); ok {
+		p.SetAllocationstate(allocationstate.(string))
+	}
+
+	if dns2, ok := d.GetOk("dns2"); ok {
+		p.SetDns2(dns2.(string))
+	}
+
+	if domain, ok := d.GetOk("domain"); ok {
+		p.SetDomain(domain.(string))
+	}
+
+	if domainid, ok := d.GetOk("domainid"); ok {
+		p.SetDomainid(domainid.(string))
+	}
+
+	if guestcidraddress, ok := d.GetOk("guestcidraddress"); ok {
+		p.SetGuestcidraddress(guestcidraddress.(string))
+	}
+
+	if internaldns2, ok := d.GetOk("internaldns2"); ok {
+		p.SetInternaldns2(internaldns2.(string))
+	}
+
+	if ip6dns1, ok := d.GetOk("ip6dns1"); ok {
+		p.SetIp6dns1(ip6dns1.(string))
+	}
+
+	if ip6dns2, ok := d.GetOk("ip6dns2"); ok {
+		p.SetIp6dns2(ip6dns2.(string))
+	}
+
+	if isedge, ok := d.GetOkExists("isedge"); ok {
+		p.SetIsedge(isedge.(bool))
+	}
+
+	if localstorageenabled, ok := d.GetOkExists("localstorageenabled"); ok {
+		p.SetLocalstorageenabled(localstorageenabled.(bool))
+	}
+
+	if securitygroupenabled, ok := d.GetOkExists("securitygroupenabled"); ok {
+		p.SetSecuritygroupenabled(securitygroupenabled.(bool))
+	}
 
 	log.Printf("[DEBUG] Creating Zone %s", name)
 	n, err := cs.Zone.CreateZone(p)
@@ -99,10 +193,82 @@ func resourceCloudStackZoneRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("internal_dns1", z.Internaldns1)
 	d.Set("network_type", z.Networktype)
 
+	// Set optional fields
+	d.Set("allocationstate", z.Allocationstate)
+	d.Set("dns2", z.Dns2)
+	d.Set("domain", z.Domain)
+	d.Set("domainid", z.Domainid)
+	d.Set("guestcidraddress", z.Guestcidraddress)
+	d.Set("internaldns2", z.Internaldns2)
+	d.Set("ip6dns1", z.Ip6dns1)
+	d.Set("ip6dns2", z.Ip6dns2)
+	d.Set("localstorageenabled", z.Localstorageenabled)
+	d.Set("securitygroupenabled", z.Securitygroupsenabled)
+
 	return nil
 }
 
-func resourceCloudStackZoneUpdate(d *schema.ResourceData, meta interface{}) error { return nil }
+func resourceCloudStackZoneUpdate(d *schema.ResourceData, meta interface{}) error {
+	cs := meta.(*cloudstack.CloudStackClient)
+
+	// Create a new parameter struct
+	p := cs.Zone.NewUpdateZoneParams(d.Id())
+
+	// Check for changes and update parameters
+	if d.HasChange("allocationstate") {
+		p.SetAllocationstate(d.Get("allocationstate").(string))
+	}
+
+	if d.HasChange("dns1") {
+		p.SetDns1(d.Get("dns1").(string))
+	}
+
+	if d.HasChange("dns2") {
+		p.SetDns2(d.Get("dns2").(string))
+	}
+
+	if d.HasChange("domain") {
+		p.SetDomain(d.Get("domain").(string))
+	}
+
+	if d.HasChange("guestcidraddress") {
+		p.SetGuestcidraddress(d.Get("guestcidraddress").(string))
+	}
+
+	if d.HasChange("internal_dns1") {
+		p.SetInternaldns1(d.Get("internal_dns1").(string))
+	}
+
+	if d.HasChange("internaldns2") {
+		p.SetInternaldns2(d.Get("internaldns2").(string))
+	}
+
+	if d.HasChange("ip6dns1") {
+		p.SetIp6dns1(d.Get("ip6dns1").(string))
+	}
+
+	if d.HasChange("ip6dns2") {
+		p.SetIp6dns2(d.Get("ip6dns2").(string))
+	}
+
+	if d.HasChange("localstorageenabled") {
+		p.SetLocalstorageenabled(d.Get("localstorageenabled").(bool))
+	}
+
+	if d.HasChange("name") {
+		p.SetName(d.Get("name").(string))
+	}
+
+	// Update the zone
+	log.Printf("[DEBUG] Updating Zone %s", d.Get("name").(string))
+	_, err := cs.Zone.UpdateZone(p)
+
+	if err != nil {
+		return fmt.Errorf("Error updating Zone: %s", err)
+	}
+
+	return resourceCloudStackZoneRead(d, meta)
+}
 
 func resourceCloudStackZoneDelete(d *schema.ResourceData, meta interface{}) error {
 	cs := meta.(*cloudstack.CloudStackClient)

--- a/cloudstack/resource_cloudstack_zone_test.go
+++ b/cloudstack/resource_cloudstack_zone_test.go
@@ -1,0 +1,259 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package cloudstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudStackZone_basic(t *testing.T) {
+	var zone cloudstack.Zone
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackZone_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackZoneExists(
+						"cloudstack_zone.foo", &zone),
+					testAccCheckCloudStackZoneAttributes(&zone),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "name", "terraform-zone"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "dns1", "8.8.8.8"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "internal_dns1", "8.8.4.4"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "network_type", "Advanced"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudStackZone_update(t *testing.T) {
+	var zone cloudstack.Zone
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackZone_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackZoneExists(
+						"cloudstack_zone.foo", &zone),
+					testAccCheckCloudStackZoneAttributes(&zone),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "name", "terraform-zone"),
+				),
+			},
+			{
+				Config: testAccCloudStackZone_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackZoneExists(
+						"cloudstack_zone.foo", &zone),
+					testAccCheckCloudStackZoneUpdatedAttributes(&zone),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "name", "terraform-zone-updated"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "dns2", "8.8.4.4"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.foo", "internaldns2", "8.8.8.8"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudStackZoneExists(
+	n string, zone *cloudstack.Zone) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No zone ID is set")
+		}
+
+		cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+		z, _, err := cs.Zone.GetZoneByID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if z.Id != rs.Primary.ID {
+			return fmt.Errorf("Zone not found")
+		}
+
+		*zone = *z
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackZoneAttributes(
+	zone *cloudstack.Zone) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if zone.Name != "terraform-zone" {
+			return fmt.Errorf("Bad name: %s", zone.Name)
+		}
+
+		if zone.Dns1 != "8.8.8.8" {
+			return fmt.Errorf("Bad DNS1: %s", zone.Dns1)
+		}
+
+		if zone.Internaldns1 != "8.8.4.4" {
+			return fmt.Errorf("Bad internal DNS1: %s", zone.Internaldns1)
+		}
+
+		if zone.Networktype != "Advanced" {
+			return fmt.Errorf("Bad network type: %s", zone.Networktype)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackZoneUpdatedAttributes(
+	zone *cloudstack.Zone) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if zone.Name != "terraform-zone-updated" {
+			return fmt.Errorf("Bad name: %s", zone.Name)
+		}
+
+		if zone.Dns2 != "8.8.4.4" {
+			return fmt.Errorf("Bad DNS2: %s", zone.Dns2)
+		}
+
+		if zone.Internaldns2 != "8.8.8.8" {
+			return fmt.Errorf("Bad internal DNS2: %s", zone.Internaldns2)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudStackZoneDestroy(s *terraform.State) error {
+	cs := testAccProvider.Meta().(*cloudstack.CloudStackClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cloudstack_zone" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No zone ID is set")
+		}
+
+		_, _, err := cs.Zone.GetZoneByID(rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Zone %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func TestAccCloudStackZone_extended(t *testing.T) {
+	var zone cloudstack.Zone
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudStackZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudStackZone_extended,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudStackZoneExists(
+						"cloudstack_zone.extended", &zone),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "name", "terraform-zone-extended"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "dns1", "8.8.8.8"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "dns2", "8.8.4.4"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "internal_dns1", "8.8.4.4"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "internaldns2", "8.8.8.8"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "network_type", "Advanced"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "guestcidraddress", "10.1.1.0/24"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "domain", "example.com"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "localstorageenabled", "true"),
+					resource.TestCheckResourceAttr(
+						"cloudstack_zone.extended", "securitygroupenabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCloudStackZone_basic = `
+resource "cloudstack_zone" "foo" {
+  name = "terraform-zone"
+  dns1 = "8.8.8.8"
+  internal_dns1 = "8.8.4.4"
+  network_type = "Advanced"
+}
+`
+
+const testAccCloudStackZone_update = `
+resource "cloudstack_zone" "foo" {
+  name = "terraform-zone-updated"
+  dns1 = "8.8.8.8"
+  dns2 = "8.8.4.4"
+  internal_dns1 = "8.8.4.4"
+  internaldns2 = "8.8.8.8"
+  network_type = "Advanced"
+}
+`
+
+const testAccCloudStackZone_extended = `
+resource "cloudstack_zone" "extended" {
+  name = "terraform-zone-extended"
+  dns1 = "8.8.8.8"
+  dns2 = "8.8.4.4"
+  internal_dns1 = "8.8.4.4"
+  internaldns2 = "8.8.8.8"
+  network_type = "Advanced"
+  guestcidraddress = "10.1.1.0/24"
+  domain = "example.com"
+  localstorageenabled = true
+  securitygroupenabled = true
+}
+`

--- a/website/docs/d/zone.html.markdown
+++ b/website/docs/d/zone.html.markdown
@@ -10,15 +10,26 @@ description: |-
 
 Use this datasource to get information about a zone for use in other resources.
 
-### Example Usage
+## Example Usage
 
 ```hcl
-  data "cloudstack_zone" "zone-data-source"{
-    filter{
+data "cloudstack_zone" "zone-data-source" {
+  filter {
     name = "name"
-    value="TestZone"
-    }
+    value = "TestZone"
   }
+}
+
+# Access zone attributes
+output "zone_details" {
+  value = {
+    name = data.cloudstack_zone.zone-data-source.name
+    dns1 = data.cloudstack_zone.zone-data-source.dns1
+    dns2 = data.cloudstack_zone.zone-data-source.dns2
+    guestcidraddress = data.cloudstack_zone.zone-data-source.guestcidraddress
+    securitygroupenabled = data.cloudstack_zone.zone-data-source.securitygroupenabled
+  }
+}
 ```
 
 ### Argument Reference
@@ -33,3 +44,13 @@ The following attributes are exported:
 * `dns1` - The first DNS for the Zone.
 * `internal_dns1` - The first internal DNS for the Zone.
 * `network_type` - The network type of the zone; can be Basic or Advanced.
+* `allocationstate` - Allocation state of this Zone for allocation of new resources.
+* `dns2` - The second DNS for the Zone.
+* `domain` - Network domain name for the networks in the zone.
+* `domainid` - The ID of the containing domain, null for public zones.
+* `guestcidraddress` - The guest CIDR address for the Zone.
+* `internaldns2` - The second internal DNS for the Zone.
+* `ip6dns1` - The first DNS for IPv6 network in the Zone.
+* `ip6dns2` - The second DNS for IPv6 network in the Zone.
+* `localstorageenabled` - True if local storage offering enabled, false otherwise.
+* `securitygroupenabled` - True if network is security group enabled, false otherwise.

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -11,14 +11,23 @@ description: |-
 A `cloudstack_zone` resource manages a zone within CloudStack.
 
 ## Example Usage
+
 ```hcl
 resource "cloudstack_zone" "example" {
     name = "example-zone"
     dns1 = "8.8.8.8"
     internal_dns1 = "8.8.4.4"
     network_type = "Basic"
+    
+    # Optional parameters
+    dns2 = "8.8.4.4"
+    internaldns2 = "8.8.8.8"
+    guestcidraddress = "10.1.1.0/24"
+    localstorageenabled = true
+    securitygroupenabled = true
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -26,7 +35,18 @@ The following arguments are supported:
 * `name` - (Required) The name of the zone.
 * `dns1` - (Required) The DNS server  1 for the zone.
 * `internal_dns1` - (Required) The internal DNS server  1 for the zone.
-* `network_type` - (Required) The type of network to use for the zone.
+* `network_type` - (Required, ForceNew) The type of network to use for the zone.
+* `allocationstate` - (Optional) Allocation state of this Zone for allocation of new resources.
+* `dns2` - (Optional) The second DNS for the Zone.
+* `domain` - (Optional) Network domain name for the networks in the zone.
+* `domainid` - (Optional, ForceNew) The ID of the containing domain, null for public zones.
+* `guestcidraddress` - (Optional) The guest CIDR address for the Zone.
+* `internaldns2` - (Optional) The second internal DNS for the Zone.
+* `ip6dns1` - (Optional) The first DNS for IPv6 network in the Zone.
+* `ip6dns2` - (Optional) The second DNS for IPv6 network in the Zone.
+* `isedge` - (Optional, ForceNew) True if the zone is an edge zone, false otherwise.
+* `localstorageenabled` - (Optional) True if local storage offering enabled, false otherwise.
+* `securitygroupenabled` - (Optional, ForceNew) True if network is security group enabled, false otherwise.
 
 ## Attributes Reference
 
@@ -37,10 +57,21 @@ The following attributes are exported:
 * `dns1` - The DNS server  1 for the zone.
 * `internal_dns1` - The internal DNS server  1 for the zone.
 * `network_type` - The type of network to use for the zone.
+* `allocationstate` - Allocation state of this Zone for allocation of new resources.
+* `dns2` - The second DNS for the Zone.
+* `domain` - Network domain name for the networks in the zone.
+* `domainid` - The ID of the containing domain, null for public zones.
+* `guestcidraddress` - The guest CIDR address for the Zone.
+* `internaldns2` - The second internal DNS for the Zone.
+* `ip6dns1` - The first DNS for IPv6 network in the Zone.
+* `ip6dns2` - The second DNS for IPv6 network in the Zone.
+* `localstorageenabled` - True if local storage offering enabled, false otherwise.
+* `securitygroupenabled` - True if network is security group enabled, false otherwise.
 
 ## Import
 
 Zones can be imported; use `<ZONEID>` as the import ID. For example:
+
 ```shell
-$ terraform import cloudstack_zone.example <ZONEID>
+terraform import cloudstack_zone.example <ZONEID>
 ```


### PR DESCRIPTION
- Added optional attributes: allocationstate, dns2, domain, domainid, guestcidraddress, internaldns2, ip6dns1, ip6dns2, localstorageenabled, and securitygroupenabled to the cloudstack_zone resource.
- Updated the data source to set new optional fields.
- Expanded example usage in documentation for clarity.
- Implemented comprehensive acceptance tests for basic and extended configurations.